### PR TITLE
Make output of build failure more verbose

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,4 +33,4 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.java }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-${{ matrix.java}}-gradle
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build --stacktrace --info


### PR DESCRIPTION
Purely to expose the errors causing build to fail in the version PR by adding flags to gradle.  Delete me!