### PR TITLE
Fix Unit Test Failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ gradle-app.setting
 
 # IDE
 .idea
+.vscode
+settings.json
 
 # Mac Stuff
 .DS_Store

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,10 +51,20 @@ checkstyle {
     toolVersion = "8.25"
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 tasks.test {
     useJUnitPlatform()
     testLogging {
         events("passed", "skipped", "failed")
+    }
+    configure<JacocoTaskExtension> {
+        excludes = mutableListOf("org/hl7/fhir/r4/formats/JsonParser",
+                "org/hl7/fhir/r5/formats/JsonParser",
+                "org/hl7/fhir/r4/formats/XmlParser",
+                "org/hl7/fhir/r5/formats/XmlParser")
     }
 }
 

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -11,7 +11,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mitre.inferno.rest.IgResponse;
 
@@ -19,9 +20,14 @@ import org.mitre.inferno.rest.IgResponse;
 public class ValidatorTest {
   private static Validator validator;
 
-  @BeforeAll
-  static void setUp() throws Exception {
+  @BeforeEach
+  public void setUp() throws Exception {
     validator = new Validator("./igs");
+  }
+
+  @AfterEach
+  public void cleanUp() throws Exception {
+    validator = null;
   }
 
   @Test
@@ -82,7 +88,7 @@ public class ValidatorTest {
       fail();
     }
   }
-
+  
   @Test
   void validateMultipleProfiles() {
     try {

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -105,8 +105,6 @@ public class ValidatorTest {
     List<String> profilesToLoad = Arrays.asList(
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-comorbidities-parent",
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status",
-        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-genetic-variant",
-        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-genomics-report",
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient",
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-request",
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-surgical-procedure",


### PR DESCRIPTION
This addresses failures caused by JaCoCo Plugin's inability to cover some of the larger classes of the validator (Json and XMLParser). There is still a failing test within the ValidatorTest file as the IGs returned by the package server no longer include the base fhir IG. I'm not sure what the best way forward is regarding this -- should we just change the package we look for to something well-known, like SMART of Bulk Data?  