### PR TITLE
FI-1889: Update core dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM openjdk:11 AS build
 
-# RUN curl -ksSL https://gitlab.mitre.org/mitre-scripts/mitre-pki/raw/master/os_scripts/install_certs.sh | JAVA_HOME=/usr/local/openjdk-11 MODE=java sh
-# If using under Zscalar, comment out the above and run using: 'docker build --no-cache -t hl7_validator .'
+# RUN curl -ksSL https://gitlab.mitre.org/mitre-scripts/mitre-pki/raw/master/os_scripts/install_certs.sh | MODE=ubuntu sh
 
 WORKDIR /home
 # Grab Gradle first so it can be cached
@@ -21,8 +20,7 @@ RUN tar -xvf build/distributions/InfernoValidationService-*.tar
 
 FROM openjdk:11
 
-# RUN curl -ksSL https://gitlab.mitre.org/mitre-scripts/mitre-pki/raw/master/os_scripts/install_certs.sh | JAVA_HOME=/usr/local/openjdk-11 MODE=java sh
-# If using under Zscalar, comment out the above and run using: 'docker build --no-cache -t hl7_validator .'
+# RUN curl -ksSL https://gitlab.mitre.org/mitre-scripts/mitre-pki/raw/master/os_scripts/install_certs.sh | MODE=ubuntu sh
 
 WORKDIR /home
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     // https://chat.fhir.org/#narrow/stream/179166-implementers/topic/New.20validator.20JAR.20location
     // the ig-publisher uses this one too
     // https://github.com/HL7/fhir-ig-publisher/blob/master/pom.xml#L68
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "5.6.71")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "5.6.93")
 
     // validator dependencies (should be able to get these automatically?)
     implementation("org.apache.commons","commons-compress", "1.19")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,12 @@ jacoco {
     toolVersion = "0.8.8"
 }
 
+tasks {
+  withType<JavaCompile> {
+    options.compilerArgs.add("-Xlint:deprecation")
+  }
+}
+
 tasks.test {
     environment(mapOf("DISABLE_TX" to "true"))
     useJUnitPlatform()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.2.0
+version=2.2.1

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -15,7 +15,6 @@ import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.formats.FormatUtilities;
 import org.hl7.fhir.r5.model.CodeType;
 import org.hl7.fhir.r5.model.CodeableConcept;
-import org.hl7.fhir.utilities.FhirPublication;
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.r5.model.IntegerType;
 import org.hl7.fhir.r5.model.OperationOutcome;
@@ -23,6 +22,7 @@ import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
 import org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent;
 import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.utilities.FhirPublication;
 import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import org.hl7.fhir.utilities.npm.NpmPackage;
@@ -54,7 +54,12 @@ public class Validator {
     final String txLog = null;
     final String fhirVersion = "4.0.1";
 
-    ValidationEngineBuilder engineBuilder = new ValidationEngineBuilder().withTxServer(txServer, txLog, FhirPublication.fromCode(fhirVersion));
+    ValidationEngineBuilder engineBuilder =
+        new ValidationEngineBuilder().withTxServer(
+                                                   txServer,
+                                                   txLog,
+                                                   FhirPublication.fromCode(fhirVersion)
+                                                   );
     hl7Validator = engineBuilder.fromSource(definitions);
     
     // The two lines below turn off URL resolution checking in the validator. 
@@ -69,7 +74,14 @@ public class Validator {
     File[] igFiles = dir.listFiles((d, name) -> name.endsWith(".tgz"));
     if (igFiles != null) {
       for (File igFile : igFiles) {
-        hl7Validator.getIgLoader().loadIg(hl7Validator.getIgs(), hl7Validator.getBinaries(), igFile.getAbsolutePath(), true);
+        hl7Validator
+            .getIgLoader()
+            .loadIg(
+                    hl7Validator.getIgs(),
+                    hl7Validator.getBinaries(),
+                    igFile.getAbsolutePath(),
+                    true
+                    );
       }
     }
 
@@ -101,7 +113,10 @@ public class Validator {
    * @return a sorted list of distinct structure canonicals
    */
   public List<String> getStructures() {
-    List<StructureDefinition> structures = hl7Validator.getContext().fetchResourcesByType(StructureDefinition.class);
+    List<StructureDefinition> structures =
+        hl7Validator
+            .getContext()
+            .fetchResourcesByType(StructureDefinition.class);
     return structures
         .stream()
         .map(StructureDefinition::getUrl)
@@ -126,12 +141,24 @@ public class Validator {
     } catch (Exception e) {
       // Add our own OperationOutcome for errors that break the ValidationEngine
       OperationOutcome.IssueSeverity sev = OperationOutcome.IssueSeverity.FATAL;
-      OperationOutcomeIssueComponent issue = new OperationOutcomeIssueComponent(sev, IssueType.STRUCTURE);
+      OperationOutcomeIssueComponent issue = new OperationOutcomeIssueComponent(
+                                                                                sev,
+                                                                                IssueType.STRUCTURE
+                                                                                );
       issue.setDiagnostics(e.getMessage());
       issue.setDetails(new CodeableConcept().setText(e.getMessage()));
-      issue.addExtension("http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-line", new IntegerType(1));
-      issue.addExtension("http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-col", new IntegerType(1));
-      issue.addExtension("http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-source", new CodeType("ValidationService"));
+      issue.addExtension(
+                         "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-line",
+                         new IntegerType(1)
+                         );
+      issue.addExtension(
+                         "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-col",
+                         new IntegerType(1)
+                         );
+      issue.addExtension(
+                         "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-source",
+                         new CodeType("ValidationService")
+                         );
       oo = new OperationOutcome(issue);
     }
     return oo;
@@ -203,7 +230,14 @@ public class Validator {
     NpmPackage npm = findCustomPackage(id, version);
     // Fallback to packages from packages.fhir.org if no custom packages match
     if (npm == null) {
-      hl7Validator.getIgLoader().loadIg(hl7Validator.getIgs(), hl7Validator.getBinaries(), id + (version != null ? "#" + version : ""), true);
+      hl7Validator
+          .getIgLoader()
+          .loadIg(
+                  hl7Validator.getIgs(),
+                  hl7Validator.getBinaries(),
+                  id + (version != null ? "#" + version : ""),
+                  true
+                  );
       npm = packageManager.loadPackage(id, version);
     }
     return IgResponse.fromPackage(npm);
@@ -220,7 +254,14 @@ public class Validator {
     temp.deleteOnExit();
     try {
       FileUtils.writeByteArrayToFile(temp, content);
-      hl7Validator.getIgLoader().loadIg(hl7Validator.getIgs(), hl7Validator.getBinaries(), temp.getCanonicalPath(), true);
+      hl7Validator
+          .getIgLoader()
+          .loadIg(
+                  hl7Validator.getIgs(),
+                  hl7Validator.getBinaries(),
+                  temp.getCanonicalPath(),
+                  true
+                  );
     } finally {
       temp.delete();
     }

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -26,7 +26,6 @@ import org.hl7.fhir.utilities.FhirPublication;
 import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import org.hl7.fhir.utilities.npm.NpmPackage;
-import org.hl7.fhir.utilities.npm.ToolsVersion;
 import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
 import org.hl7.fhir.validation.BaseValidator;
 import org.hl7.fhir.validation.BaseValidator.ValidationControl;
@@ -90,7 +89,7 @@ public class Validator {
     hl7Validator.setAnyExtensionsAllowed(true);
     hl7Validator.prepare();
 
-    packageManager = new FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
+    packageManager = new FilesystemPackageCacheManager(true);
     loadedPackages = new HashMap<>();
   }
 


### PR DESCRIPTION
# Summary
Upgrade fhir core dependency to address https://www.cve.org/CVERecord?id=CVE-2023-24057

# Testing Guidance
`docker build -t wrapper .`
Replace the wrapper image in `docker-compose.background.yml` of the test kit you want to check with `wrapper`.
