### PR TITLE
Fix failing test due to mCODE profile names changing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation("com.sparkjava", "spark-core", "2.9.1")
 
     // Testing stuff
-    testImplementation("org.junit.jupiter", "junit-jupiter", "5.5.2")
+    testImplementation("org.junit.jupiter", "junit-jupiter", "5.9.3")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ tasks {
 
 tasks.test {
     environment(mapOf("DISABLE_TX" to "true"))
+    maxHeapSize = "6144m"
     useJUnitPlatform()
     testLogging {
         events("passed", "skipped", "failed")

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -107,8 +107,8 @@ public class ValidatorTest {
 
   @Test
   void loadIg() throws Exception {
+    // A small subset of the profiles in mCODE 3.0.0
     List<String> profilesToLoad = Arrays.asList(
-        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-comorbidities-parent",
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status",
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient",
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-request",
@@ -118,6 +118,8 @@ public class ValidatorTest {
     assertTrue(profilesToLoad.stream().noneMatch(this::isProfileLoaded));
 
     // Because the version isn't given, this should load the "current" version of hl7.fhir.us.mcode
+    // Note this means that if a new version is published that changes the profile names
+    // (as has happened in updates 1->2 and 2->3) this test may fail
     IgResponse ig = validator.loadIg("hl7.fhir.us.mcode", null);
     assertEquals("hl7.fhir.us.mcode", ig.id);
     assertTrue(ig.profiles.containsAll(profilesToLoad));


### PR DESCRIPTION
# Summary
Just a quick update to one of the unit tests so that it passes. mCODE 3.0.0-ballot has been released recently, and one of the changes from v2 to v3 is renaming the "Comorbidities Parent" profile to just "Comorbidities". Fetching an IG without a specific version will get the "current", so it's now fetching 3.0.0. 
I removed that one assertion that checks that the "comorbidities-parent" profile was loaded so the test now passes.
I could have added more assertions but since it's already only checking a subset I figured this is good enough.

I also noticed the tests were failing on CI without a useful error message, which I suspect was due to out of memory errors. I set heap memory available for tests to 6 GB since that seemed to be enough to make it pass locally. (Also the same size we set for Synthea)

I also updated the JUnit dependency to make unit tests work in Eclipse. There should be no other noticeable impact from that change.

# Testing Guidance
`./gradlew test` - all tests should pass, locally and on CI
