### PR TITLE
Enable toggling display issues as warnings or errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Run without terminology validation:
 docker run -p 4567:4567 --env DISABLE_TX=true hl7_validator
 ```
 
+By default, the validator will return errors when a code display doesn't match the expected value from the terminology server. To return warnings instead:
+
+```shell script
+docker run -p 4567:4567 --env DISPLAY_ISSUES_ARE_WARNINGS=true hl7_validator
+```
+
 ## Creating an Uber Jar
 
 An uber jar can be created with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,10 +15,7 @@ repositories {
 }
 
 dependencies {
-    // https://chat.fhir.org/#narrow/stream/179166-implementers/topic/New.20validator.20JAR.20location
-    // the ig-publisher uses this one too
-    // https://github.com/HL7/fhir-ig-publisher/blob/master/pom.xml#L68
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "5.6.93")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.0.16")
 
     // validator dependencies (should be able to get these automatically?)
     implementation("org.apache.commons","commons-compress", "1.19")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.0.16")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.0.21")
 
     // validator dependencies (should be able to get these automatically?)
     implementation("org.apache.commons","commons-compress", "1.19")

--- a/src/main/java/org/mitre/inferno/App.java
+++ b/src/main/java/org/mitre/inferno/App.java
@@ -34,7 +34,7 @@ public class App {
   private static Validator initializeValidator() {
     Logger logger = LoggerFactory.getLogger(App.class);
     try {
-      return new Validator("./igs");
+      return new Validator("./igs", areDisplayIssuesWarnings());
     } catch (Exception e) {
       logger.error("There was an error initializing the validator:", e);
       System.exit(1);
@@ -68,10 +68,20 @@ public class App {
   }
 
   private static int getPortNumber() {
-    if (System.getenv("VALIDATOR_PORT") != null) {
-      return Integer.parseInt(System.getenv("VALIDATOR_PORT"));
+    String port = System.getenv("VALIDATOR_PORT");
+    if (port != null) {
+      return Integer.parseInt(port);
     } else {
       return 4567;
+    }
+  }
+
+  private static boolean areDisplayIssuesWarnings() {
+    String displayIssuesAreWarnings = System.getenv("DISPLAY_ISSUES_ARE_WARNINGS");
+    if (displayIssuesAreWarnings != null) {
+      return Boolean.parseBoolean(displayIssuesAreWarnings);
+    } else {
+      return false;
     }
   }
 }

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -64,7 +64,7 @@ public class Validator {
     // The two lines below turn off URL resolution checking in the validator. 
     // This eliminates the need to silence these errors elsewhere in Inferno
     // And also keeps contained resources from failing validation based solely on URL errors
-    ValidationControl vc = new BaseValidator(null, null)
+    ValidationControl vc = new BaseValidator(null, null, false)
                              .new ValidationControl(false, IssueSeverity.INFORMATION);
     hl7Validator.getValidationControl().put("Type_Specific_Checks_DT_URL_Resolve", vc);
 

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -46,6 +46,19 @@ public class Validator {
    * @throws Exception If the validator cannot be created
    */
   public Validator(String igDir) throws Exception {
+    this(igDir, false);
+  }
+
+  /**
+   * Creates the HL7 Validator to which can then be used for validation.
+   *
+   * @param igDir A directory containing tarred/gzipped IG packages
+   * @param displayIssuesAreWarnings
+   *    Toggles whether code display mismatches should be
+   *      reported as warnings (true) or errors (false).
+   * @throws Exception If the validator cannot be created
+   */
+  public Validator(String igDir, boolean displayIssuesAreWarnings) throws Exception {
     final String fhirSpecVersion = "4.0";
     final String definitions = VersionUtilities.packageForVersion(fhirSpecVersion)
         + "#" + VersionUtilities.getCurrentVersion(fhirSpecVersion);
@@ -87,6 +100,7 @@ public class Validator {
     hl7Validator.connectToTSServer(txServer, txLog, FhirPublication.fromCode(fhirVersion));
     hl7Validator.setDoNative(false);
     hl7Validator.setAnyExtensionsAllowed(true);
+    hl7Validator.setDisplayWarnings(displayIssuesAreWarnings);
     hl7Validator.prepare();
 
     packageManager = new FilesystemPackageCacheManager(true);

--- a/src/test/resources/resource_with_correct_code_display.json
+++ b/src/test/resources/resource_with_correct_code_display.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Medication",
+  "code": {
+    "coding": [
+      {
+        "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+        "code": "1191",
+        "display": "aspirin"
+      }
+    ]
+  }
+}

--- a/src/test/resources/resource_with_incorrect_code_display.json
+++ b/src/test/resources/resource_with_incorrect_code_display.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Medication",
+  "code": {
+    "coding": [
+      {
+        "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+        "code": "340584",
+        "display": "miracle juice"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Summary
Addresses FI-1994 and FI-1995

This PR bumps the HL7 validator dependency to 6.0.21 so that we can toggle whether code display errors from the terminology server are reported as warnings or errors. This also checks for a new environment variable `DISPLAY_ISSUES_ARE_WARNINGS` to toggle it on and off per instance. (Unfortunately it's a setting on the validator instance not a parameter of the validate function, so given the current architecture we can't easily toggle it per-request.) The env var was chosen to match the setting name used on the official validator CLI. The default matches the default of the official validator, where code display issues are errors.

~Note 1: this PR is marked as WIP while I continue to test it out to ensure nothing breaks elsewhere~

Note 2: I pushed the 2 changes here to separate branches so that if we want to start with just the bumped dependency version we can do that -- see branch `bump_hl7_validator`

Note 3: CI is still failing, see #60 to resolve that

# Testing Guidance
I have two minimal sample resources to test with in src/test/resources

1. Test the validator by launching it without the new env var and validating some resources. Resources with a display issue should return errors. Resources without issues should still be fine
2. Test the validator by launching it with `DISPLAY_ISSUES_ARE_WARNINGS=true` and validating resources. Resources with a display issue should return warnings. Resources without issues should still be fine
3. Test the validator by running G10 tests against it and make sure nothing unexpected breaks