### PR TITLE
FI-1223: Expose multiple software versions at /version endpoint

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -65,13 +65,12 @@ the NPM ID, version, and list of profile URLs of the loaded IG. [See here](#load
 - **Route:**
 `GET /version`
 - **Response:**
-A string representing the version of the wrapper being used.
+A JSON object containing identifiers and version numbers for the software in use, such as the version of the wrapper itself and the version of the HL7 validator.
+- **Example Response:**
+```
+{"org.hl7.fhir.validation":"5.6.93","inferno-framework/fhir-validator-wrapper":"2.2.1"}
+```
 
-### Get the validator's version
-- **Route:**
-`GET /validator-version`
-- **Response:**
-A string representing which HL7 validator version is being used.
 
 # FHIRPath Routes
 

--- a/rest-api.md
+++ b/rest-api.md
@@ -61,6 +61,18 @@ Also note that the request must have the `Content-Encoding: gzip` header.
 - **Response:**
 the NPM ID, version, and list of profile URLs of the loaded IG. [See here](#loading-a-custom-ig) for an example.
 
+### Get this wrapper's version
+- **Route:**
+`GET /version`
+- **Response:**
+A string representing the version of the wrapper being used.
+
+### Get the validator's version
+- **Route:**
+`GET /validator-version`
+- **Response:**
+A string representing which HL7 validator version is being used.
+
 # FHIRPath Routes
 
 ### Evaluate a FHIRPath expression

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -306,15 +306,11 @@ public class Validator {
   }
 
   /**
-   * Get the version of the validator.
+   * Get the version of the validator used under the hood.
    *
    * @return the validator version as a string
    */
   public String getValidatorVersion() {
-    return hl7Validator.getVersion();
-  }
-
-  public String getVersion() {
     return VersionUtil.getVersion();
   }
 

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -305,6 +305,15 @@ public class Validator {
         ));
   }
 
+  /**
+   * Get the version of the validator.
+   *
+   * @return the validator version as a string
+   */
+  public String getValidatorVersion() {
+    return hl7Validator.getVersion();
+  }
+
   public String getVersion() {
     return VersionUtil.getVersion();
   }

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -306,15 +306,6 @@ public class Validator {
   }
 
   /**
-   * Get the version of the validator used under the hood.
-   *
-   * @return the validator version as a string
-   */
-  public String getValidatorVersion() {
-    return VersionUtil.getVersion();
-  }
-
-  /**
    * Load a profile from a file.
    *
    * @param src the file path

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -65,6 +65,8 @@ public class ValidatorEndpoint {
         (req, res) -> validator.loadIg(req.params("id"), req.queryParams("version")),
         TO_JSON);
 
+    get("/validator-version", (req, res) -> validator.getValidatorVersion());
+
     get("/version", (req, res) -> Version.getVersion());
   }
 


### PR DESCRIPTION
# Summary
Updates the `/version` endpoint to return a JSON containing the version numbers of both this wrapper as well as the version of the HL7 validator. Previously this was just text of the wrapper version number.
Sample result:
```json
{"org.hl7.fhir.validation":"5.6.93","inferno-framework/fhir-validator-wrapper":"2.2.1"}
```

This PR replaces #42 mostly because that one was kind of a mess in terms of branch structure, but also it created a new route, and it called the wrong function to get a version number so it didn't actually return the right number for the HL7 validator.

In a few places I refer to this as "JSON containing the version numbers of software" so we could add more at some point if we want to and we don't have to rename/change docs again/etc. Though I don't have any reason to expect we'll actually need to do that.

# Testing Guidance
Run the app and confirm a `GET /version` returns a JSON both software versions

Note there are two other changes associated with this where other tools read the version string:
 - the g10 test kit changes are here: https://github.com/onc-healthit/onc-certification-g10-test-kit/pull/448
 - the validator app changes are here: https://github.com/inferno-framework/fhir-validator-app/pull/105