### PR TITLE
FI-2019: bump dependencies to address vulnerabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,16 +17,14 @@ repositories {
 dependencies {
     implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.0.21")
 
-    // validator dependencies (should be able to get these automatically?)
-    implementation("org.apache.commons","commons-compress", "1.19")
-    implementation("org.apache.httpcomponents", "httpclient", "4.5.10")
-    implementation("org.fhir", "ucum", "1.0.2")
+    // validator dependency needed for terminology (why can't it get this automatically?)
     implementation("com.squareup.okhttp3", "okhttp", "4.9.0")
 
     // GSON for our JSON needs
-    implementation("com.google.code.gson", "gson", "2.8.6")
+    implementation("com.google.code.gson", "gson", "2.10.1")
 
-    implementation("org.slf4j", "slf4j-log4j12", "1.7.30")
+    // Basic logging. Reload4J is a security-focused fork of Log4J 1.x
+    implementation("org.slf4j", "slf4j-reload4j", "2.0.7")
 
     // Web Server
     implementation("com.sparkjava", "spark-core", "2.9.4")


### PR DESCRIPTION
# Summary
This PR makes the following changes to the app dependencies:
1. Replaces `slf4j-log4j12` with `slf4j-reload4j` to address potential security vulnerabilities in the nested log4j dependency. `slf4j-log4j12` brought in log4j v1.2 which is very old (the major vulnerability from 2021 "Log4shell" was introduced in v2 so this was even older than that), and `slf4j-reload4j` instead brings in "reload4j" which is a fork of log4j 1.x intended to focus on addressing security issues rather than adding features. SLF4J has other log provider options but this one should be a drop-in replacement with no changes needed elsewhere.
2. Removes a couple of the HL7 validator dependencies which don't need to be listed here; as the previous code comment suggested, gradle will fetch these automatically. (You can confirm via `./gradlew dependencies` which shows the full dependency tree of the app)  For some reason though okhttp is needed but does not get included automatically, I didn't look too deep into that.
3. Bumps Google GSON to the latest version just to be proactive.

I also noticed spark is out of date, but the most recent release is also out of date and the library seems to be no longer maintained so I didn't bother: https://github.com/perwendel/spark
There are options to replace that if we decide we need to someday, for example https://github.com/javalin/javalin

# Testing Guidance
The main impact, if any, should be to logging - make sure the app still logs to console as expected.
Still I would recommend confirming validation works both with and without a terminology server because issues with the dependencies may not present until they are called (even if it compiles)
