### PR TITLE
Fi 1977 slow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("org.slf4j", "slf4j-log4j12", "1.7.30")
 
     // Web Server
-    implementation("com.sparkjava", "spark-core", "2.9.1")
+    implementation("com.sparkjava", "spark-core", "2.9.4")
 
     // Testing stuff
     testImplementation("org.junit.jupiter", "junit-jupiter", "5.9.3")

--- a/src/main/java/org/mitre/inferno/App.java
+++ b/src/main/java/org/mitre/inferno/App.java
@@ -10,7 +10,11 @@ public class App {
 
   /**
    * Starting point for the Validation Service.
-   * <p>Passing the 'prepare' argument causes the FHIR artifacts needed to be downloaded.</p>
+   * <p>
+   * Passing the 'prepare' argument causes the FHIR artifacts needed to be
+   * downloaded.
+   * </p>
+   * 
    * @param args the application initialization arguments
    */
   public static void main(String[] args) {
@@ -60,11 +64,11 @@ public class App {
     Logger logger = LoggerFactory.getLogger(App.class);
     logger.info("Starting Server...");
     SparkUtils.createServerWithRequestLog(logger);
+    Endpoints.setupLoadingRoutes(getPortNumber());
     Endpoints.getInstance(
         initializeValidator(),
         initializePathEvaluator(),
-        getPortNumber()
-    );
+        getPortNumber());
   }
 
   private static int getPortNumber() {

--- a/src/main/java/org/mitre/inferno/rest/Endpoints.java
+++ b/src/main/java/org/mitre/inferno/rest/Endpoints.java
@@ -28,10 +28,12 @@ public class Endpoints {
   }
 
   /**
-   * This adds permissive CORS headers to all requests.
+   * Set up temporary routes while the validator still loads.
+   * 
+   * @param port the port to listen for requests on
    */
-  private static void setHeaders() {
-
+  public static void setupLoadingRoutes(int port) {
+    port(port);
     before((req, res) -> {
       res.header("Access-Control-Allow-Origin", "*");
       res.header("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS");
@@ -42,17 +44,6 @@ public class Endpoints {
     // requests,
     // with a 200 OK response with no content and the CORS headers above
     options("*", (req, res) -> "");
-
-  }
-
-  /**
-   * Set up temporary routes while the validator still loads.
-   * 
-   * @param port the port to listen for requests on
-   */
-  public static void setupLoadingRoutes(int port) {
-    port(port);
-    setHeaders();
 
     JsonObject warning = new JsonObject();
     warning.addProperty("Warning", "Validator still loading... please wait.");
@@ -106,7 +97,6 @@ public class Endpoints {
    * clients.
    */
   private void createRoutes() {
-    setHeaders();
 
     if (validator != null) {
       ValidatorEndpoint.getInstance(validator);

--- a/src/main/java/org/mitre/inferno/rest/Endpoints.java
+++ b/src/main/java/org/mitre/inferno/rest/Endpoints.java
@@ -3,11 +3,16 @@ package org.mitre.inferno.rest;
 import static spark.Spark.before;
 import static spark.Spark.options;
 import static spark.Spark.port;
+import static spark.Spark.get;
+import static spark.Spark.post;
+import static spark.Spark.put;
+import static spark.Spark.unmap;
 
 import com.google.gson.Gson;
 import org.mitre.inferno.FHIRPathEvaluator;
 import org.mitre.inferno.Validator;
 import spark.ResponseTransformer;
+import com.google.gson.JsonObject;
 
 public class Endpoints {
   public static final ResponseTransformer TO_JSON = new Gson()::toJson;
@@ -16,44 +21,92 @@ public class Endpoints {
   private final Validator validator;
   private final FHIRPathEvaluator pathEvaluator;
 
-  private Endpoints(Validator validator, FHIRPathEvaluator evaluator, int port) {
+  private Endpoints(Validator validator, FHIRPathEvaluator evaluator) {
     this.validator = validator;
     this.pathEvaluator = evaluator;
-    port(port);
     createRoutes();
   }
 
   /**
-   * Get the existing Endpoints or create one if it does not already exist.
-   *
-   * @param validator the Validator that should be used at the /validator endpoint.
-   *                  Passing null will skip setting up the /validator endpoint.
-   * @param evaluator the FHIRPathEvaluator that should be used at the /fhirpath endpoint.
-   *                  Passing null will skip setting up the /fhirpath endpoint.
-   * @param port the port to listen for requests on
-   * @return the singleton Endpoints
+   * This adds permissive CORS headers to all requests.
    */
-  public static Endpoints getInstance(Validator validator, FHIRPathEvaluator evaluator, int port) {
-    if (endpoints == null) {
-      endpoints = new Endpoints(validator, evaluator, port);
-    }
-    return endpoints;
-  }
+  private static void setHeaders() {
 
-  /**
-   * Creates the API routes for receiving and processing HTTP requests from clients.
-   */
-  private void createRoutes() {
-    // This adds permissive CORS headers to all requests
     before((req, res) -> {
       res.header("Access-Control-Allow-Origin", "*");
       res.header("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS");
       res.header("Access-Control-Allow-Headers", "*");
     });
 
-    // This responds to OPTIONS requests, used by browsers to "preflight" check CORS requests,
+    // This responds to OPTIONS requests, used by browsers to "preflight" check CORS
+    // requests,
     // with a 200 OK response with no content and the CORS headers above
     options("*", (req, res) -> "");
+
+  }
+
+  /**
+   * Set up temporary routes while the validator still loads.
+   * 
+   * @param port the port to listen for requests on
+   */
+  public static void setupLoadingRoutes(int port) {
+    port(port);
+    setHeaders();
+
+    JsonObject warning = new JsonObject();
+    warning.addProperty("Warning", "Validator still loading... please wait.");
+
+    get("*", (req, res) -> {
+      res.type("application/fhir+json");
+      return warning;
+    });
+    post("*", (req, res) -> {
+      res.type("application/fhir+json");
+      return warning;
+    });
+    put("*", (req, res) -> {
+      res.type("application/fhir+json");
+      return warning;
+    });
+  }
+
+  /**
+   * Remove temporary routes set. This is meant to be called once the validator
+   * has been loaded.
+   */
+  public static void teardownLoadingRoutes() {
+    unmap("*", "get");
+    unmap("*", "post");
+    unmap("*", "put");
+  }
+
+  /**
+   * Get the existing Endpoints or create one if it does not already exist.
+   *
+   * @param validator the Validator that should be used at the /validator
+   *                  endpoint.
+   *                  Passing null will skip setting up the /validator endpoint.
+   * @param evaluator the FHIRPathEvaluator that should be used at the /fhirpath
+   *                  endpoint.
+   *                  Passing null will skip setting up the /fhirpath endpoint.
+   * @param port      the port to listen for requests on
+   * @return the singleton Endpoints
+   */
+  public static Endpoints getInstance(Validator validator, FHIRPathEvaluator evaluator, int port) {
+    teardownLoadingRoutes();
+    if (endpoints == null) {
+      endpoints = new Endpoints(validator, evaluator);
+    }
+    return endpoints;
+  }
+
+  /**
+   * Creates the API routes for receiving and processing HTTP requests from
+   * clients.
+   */
+  private void createRoutes() {
+    setHeaders();
 
     if (validator != null) {
       ValidatorEndpoint.getInstance(validator);


### PR DESCRIPTION
# Summary
Set temporary routes while the validator loads. These are unmapped and proper routes are set once the IGs are loaded and the validator is instantiated. 


