### PR TITLE
Quick Fixes: Sort Loaded IGs, Enable /version Immediately

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,9 +5,9 @@ name: Java CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -32,7 +32,6 @@ import org.hl7.fhir.validation.BaseValidator;
 import org.hl7.fhir.validation.BaseValidator.ValidationControl;
 import org.hl7.fhir.validation.ValidationEngine;
 import org.hl7.fhir.validation.ValidationEngine.ValidationEngineBuilder;
-import org.hl7.fhir.validation.cli.utils.VersionUtil;
 import org.mitre.inferno.rest.IgResponse;
 
 public class Validator {

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +86,9 @@ public class Validator {
     File dir = new File(igDir);
     File[] igFiles = dir.listFiles((d, name) -> name.endsWith(".tgz"));
     if (igFiles != null) {
+      // sort the files by name to ensure a consistent order -- see File.compareTo(File)
+      // https://docs.oracle.com/javase/8/docs/api/java/io/File.html#compareTo-java.io.File-
+      Arrays.sort(igFiles);
       for (File igFile : igFiles) {
         hl7Validator
             .getIgLoader()

--- a/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
+++ b/src/main/java/org/mitre/inferno/rest/ValidatorEndpoint.java
@@ -7,9 +7,7 @@ import static spark.Spark.put;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.hl7.fhir.r5.formats.JsonParser;
 import org.hl7.fhir.r5.model.OperationOutcome;
@@ -66,8 +64,6 @@ public class ValidatorEndpoint {
     put("/igs/:id",
         (req, res) -> validator.loadIg(req.params("id"), req.queryParams("version")),
         TO_JSON);
-
-    get("/version", (req, res) -> buildVersionResponse(), TO_JSON);
   }
 
   /**
@@ -88,22 +84,5 @@ public class ValidatorEndpoint {
 
     OperationOutcome oo = validator.validate(resource, patientProfiles);
     return new JsonParser().composeString(oo);
-  }
-
-  /**
-   * Build a Map of the library versions used by this validator.
-   *
-   * @return a Map of library identifier -> version string
-   */
-  private Map<String,String> buildVersionResponse() {
-    // full package names used here only to make it more obvious what's going on
-    // since the class names aren't distinct enough
-    String hl7ValidatorVersion = org.hl7.fhir.validation.cli.utils.VersionUtil.getVersion();
-    String wrapperVersion = org.mitre.inferno.Version.getVersion();
-
-    Map<String, String> versions = new HashMap<>();
-    versions.put("org.hl7.fhir.validation", hl7ValidatorVersion);
-    versions.put("inferno-framework/fhir-validator-wrapper", wrapperVersion);
-    return versions;
   }
 }


### PR DESCRIPTION
# Summary
A few quick fixes based on issues identified in QA:

1. Unfortunately the internal HL7 validator has some kind of state such that the order in which IGs are loaded can produce different results. The short-term fix is to sort the File array by name, to ensure that the ordering is consistent. (The implications of the specific order of any particular set of IGs is out of scope here. Finding the best ordering is left as an exercise for the user)

2. The `/version` endpoint should be accessible immediately when the server starts, since it does not depend on the internal validator instance. Various apps that check the version work better when they receive the expected result vs an OperationOutcome.  There is no change to the code here, it just moved from `ValidatorEndpoint.java` to `Endpoint.java` to fit the call sequence.

3. The branch `master` was renamed to `main` which broke our Actions. Updated those so they actually run for PRs now and don't block forever.

# Testing Guidance
Both changes are much easier to test if you have multiple IGs in the `./igs` directory. The only way to see the order the IGs were loaded in is to watch the logs.