### PR TITLE
FI-2154 Enable dependabot for dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/" # Location of package manifests (ie, build.gradle)
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
 
@@ -24,6 +27,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Setup Gradle to generate and submit dependency graphs
+        uses: gradle/gradle-build-action@v2
+        with:
+          dependency-graph: generate-and-submit
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Cache Gradle packages

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           dependency-graph: generate-and-submit
+        if: github.ref == 'refs/heads/main'
+        # only run this step on on main branch, not PRs
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Cache Gradle packages


### PR DESCRIPTION
# Summary
This PR enables dependency management with dependabot:
1. The `dependabot.yml` file tells dependabot this is a gradle-based repo and it should be able to handle simple version bumps. 
References:  
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates  
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#supported-repositories-and-ecosystems  



2. The new gradle-build-action will enable security warnings on the security tab.   

If you look at the security tab for the repo you'll see something like this:
![image](https://github.com/inferno-framework/fhir-validator-wrapper/assets/13512036/1c210705-8a55-4d57-9156-55d68c7f81bb)
For gradle there is an action "gradle-build-action" which can submit this dependency graph with the right settings:
https://github.com/marketplace/actions/gradle-build-action#github-dependency-graph-support

This is what the results look like on my fork  https://github.com/dehall/fhir-validator-wrapper where I've set this up:
![image](https://github.com/inferno-framework/fhir-validator-wrapper/assets/13512036/e76329d1-e158-467d-88ed-e0605e02a030)
(unfortunately that first one is a false positive but we can ignore it. ref: https://github.com/orgs/community/discussions/54553 )

# Testing Guidance
Not sure there's any other way to test this than to implement it. Consider forking the repo and applying these changes as a test if you want to explore. (Or I can give access to my fork)
