### PR TITLE
FI-2354: bump core validator library to 6.2.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.0.21")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.2.8")
 
     // validator dependency needed for terminology (why can't it get this automatically?)
     implementation("com.squareup.okhttp3", "okhttp", "4.9.0")

--- a/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
+++ b/src/main/java/org/mitre/inferno/FHIRPathEvaluator.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.context.SimpleWorkerContext;
 import org.hl7.fhir.r4.model.Base;
-import org.hl7.fhir.r4.utils.FHIRPathEngine;
+import org.hl7.fhir.r4.fhirpath.FHIRPathEngine;
 
 public class FHIRPathEvaluator extends FHIRPathEngine {
 

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -77,7 +77,7 @@ public class Validator {
     // The two lines below turn off URL resolution checking in the validator. 
     // This eliminates the need to silence these errors elsewhere in Inferno
     // And also keeps contained resources from failing validation based solely on URL errors
-    ValidationControl vc = new BaseValidator(null, null, false)
+    ValidationControl vc = new BaseValidator(hl7Validator.getContext(), null, false)
                              .new ValidationControl(false, IssueSeverity.INFORMATION);
     hl7Validator.getValidationControl().put("Type_Specific_Checks_DT_URL_Resolve", vc);
 
@@ -106,7 +106,7 @@ public class Validator {
     hl7Validator.setDisplayWarnings(displayIssuesAreWarnings);
     hl7Validator.prepare();
 
-    packageManager = new FilesystemPackageCacheManager(true);
+    packageManager = new FilesystemPackageCacheManager.Builder().build();
     loadedPackages = new HashMap<>();
   }
 

--- a/src/main/java/org/mitre/inferno/rest/Endpoints.java
+++ b/src/main/java/org/mitre/inferno/rest/Endpoints.java
@@ -168,7 +168,7 @@ public class Endpoints {
   private static Map<String,String> buildVersionResponse() {
     // full package names used here only to make it more obvious what's going on
     // since the class names aren't distinct enough
-    String hl7ValidatorVersion = org.hl7.fhir.validation.cli.utils.VersionUtil.getVersion();
+    String hl7ValidatorVersion = org.hl7.fhir.utilities.VersionUtil.getVersion();
     String wrapperVersion = org.mitre.inferno.Version.getVersion();
 
     Map<String, String> versions = new HashMap<>();


### PR DESCRIPTION
# Summary
This PR bumps the internal hl7 validator library version to the latest - 6.2.8. The main driver for this is US Core 7 support.

There were a few minor changes needed:
- A couple classes moved around so references were updated: `VersionUtil` and `FhirPathEngine`
- `BaseValidator` constructor now requires that the "context" passed in not be null, so I passed in the context from a ValidatorEngine instance we already had. The BaseValidator is not actually used anywhere, it's just necessary to have an instance to get access to the ValidationControl internal class, so there should be no impact to this.
- `FilesystemPackageCacheManager` now uses a Builder instead of public constructors. The boolean parameter before was for "userMode" which determined the cache directory used : https://github.com/hapifhir/org.hl7.fhir.core/blob/6.0.21/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java#L123
Now the default is to use the user directory https://github.com/hapifhir/org.hl7.fhir.core/blob/6.2.8/org.hl7.fhir.utilities/src/main/java/org/hl7/fhir/utilities/npm/FilesystemPackageCacheManager.java#L122

# Testing Guidance
The US Core 7 package can be downloaded from https://build.fhir.org/ig/HL7/US-Core/downloads.html
Place this in the `./igs` folder and start the server, validate some resources, confirm it all works
