### PR TITLE
FI-3387: Bump dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,16 +15,19 @@ repositories {
 }
 
 dependencies {
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.2.8")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.4.0")
 
     // validator dependency needed for terminology (why can't it get this automatically?)
-    implementation("com.squareup.okhttp3", "okhttp", "4.9.0")
+    implementation("com.squareup.okhttp3", "okhttp", "4.12.0")
+
+    // validator dependency needed to prevent a ClassNotFoundException
+    implementation("org.fhir:ucum:1.0.8")
 
     // GSON for our JSON needs
-    implementation("com.google.code.gson", "gson", "2.10.1")
+    implementation("com.google.code.gson", "gson", "2.11.0")
 
     // Basic logging. Reload4J is a security-focused fork of Log4J 1.x
-    implementation("org.slf4j", "slf4j-reload4j", "2.0.7")
+    implementation("org.slf4j", "slf4j-reload4j", "2.0.16")
 
     // Web Server
     implementation("com.sparkjava", "spark-core", "2.9.4")

--- a/src/test/java/org/mitre/inferno/ValidatorTest.java
+++ b/src/test/java/org/mitre/inferno/ValidatorTest.java
@@ -160,19 +160,19 @@ public class ValidatorTest {
 
   @Test
   void loadIg() throws Exception {
-    // A small subset of the profiles in mCODE 3.0.0
+    // A small subset of the profiles in mCODE 4.0.0
     List<String> profilesToLoad = Arrays.asList(
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status",
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient",
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-request",
         "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-surgical-procedure",
-        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-stage-group"
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-stage"
     );
     assertTrue(profilesToLoad.stream().noneMatch(this::isProfileLoaded));
 
     // Because the version isn't given, this should load the "current" version of hl7.fhir.us.mcode
     // Note this means that if a new version is published that changes the profile names
-    // (as has happened in updates 1->2 and 2->3) this test may fail
+    // (as has happened in updates 1->2, 2->3, and 3->4) this test may fail
     IgResponse ig = validator.loadIg("hl7.fhir.us.mcode", null);
     assertEquals("hl7.fhir.us.mcode", ig.id);
     assertTrue(ig.profiles.containsAll(profilesToLoad));


### PR DESCRIPTION
# Summary
Bumps all the dependencies to the latest. Spark is the only one that doesn't have a more recent version available.

A couple things were changed in the core validator:
1. A new flag `useEcosystem` was added to some methods. I'm not entirely clear what this does but it defaults to true in the core code, so I re-used that default here. (I believe this allows it to get into some of the "special" logic that tx.fhir.org offers)
2. FilesystemPackageCacheManager.listAllIds was removed, and this was how we got the list of all IGs that are available. There doesn't seem to be an equivalent, so I copied over the relevant methods from the old version.

Also mCODE updated again so I fixed the profile names in the unit test that fetches "latest"

The extra spaces in that last changed line are to fix a checkstyle issue.

# Testing Guidance
You will want to run the [validator-app](https://github.com/inferno-framework/fhir-validator-app) as well and point it to this. One way is to run that with no changes, and run this on port 8080, eg `VALIDATOR_PORT=8080 ./gradlew run`

Upload some IGs and validate some resources. Make sure selecting `hl7.fhir.r6.core` from the IG dropdown in advanced options doesn't completely break the app, since that's the main problem we're running into now