### PR TITLE
FI-3375: Cleanup logs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.3.2
+version=2.3.3

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -171,7 +171,7 @@ public class Validator {
           + ", selected profile: " + profiles.toString()
           + " and meta.profile: " + metaProfiles);
     } catch (Exception e) {
-      LOGGER.warn("Error occurred in parsing resource for logging", e);
+      // do nothing - this is informational only, and it seems to happen often
     }
 
     OperationOutcome oo;


### PR DESCRIPTION
# Summary
The standalone validator logs are being overwhelmed by the "Error occurred in parsing resource for logging" warning and stack trace. This just removes that log line.
Looking at the other logger statements in the code, and at a snippet of today's production logs, I don't think any of the other ones need to be cleaned up.

To minimize the number of PRs, this also bumps the version to 2.3.3 in anticipation of an upcoming release. I can also split that out into another PR if people prefer that

