### PR TITLE
FI-3565: Bump core validator to 6.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.4.0")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.5.0")
 
     // validator dependency needed for terminology (why can't it get this automatically?)
     implementation("com.squareup.okhttp3", "okhttp", "4.12.0")

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -23,6 +23,7 @@ import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
 import org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent;
 import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.StructureDefinition;
+import org.hl7.fhir.r5.utils.validation.constants.ReferenceValidationPolicy;
 import org.hl7.fhir.utilities.FhirPublication;
 import org.hl7.fhir.utilities.VersionUtilities;
 import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
@@ -35,6 +36,8 @@ import org.hl7.fhir.validation.BaseValidator;
 import org.hl7.fhir.validation.BaseValidator.ValidationControl;
 import org.hl7.fhir.validation.ValidationEngine;
 import org.hl7.fhir.validation.ValidationEngine.ValidationEngineBuilder;
+import org.hl7.fhir.validation.cli.services.DisabledValidationPolicyAdvisor;
+import org.hl7.fhir.validation.instance.advisor.BasePolicyAdvisorForFullValidation;
 import org.mitre.inferno.rest.IgResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,6 +116,10 @@ public class Validator {
     hl7Validator.setDoNative(false);
     hl7Validator.setAnyExtensionsAllowed(true);
     hl7Validator.setDisplayWarnings(displayIssuesAreWarnings);
+    DisabledValidationPolicyAdvisor policyAdvisor = new DisabledValidationPolicyAdvisor();
+    policyAdvisor.setPolicyAdvisor(
+        new BasePolicyAdvisorForFullValidation(ReferenceValidationPolicy.CHECK_TYPE_IF_EXISTS));
+    hl7Validator.setPolicyAdvisor(policyAdvisor);
     hl7Validator.prepare();
 
     packageManager = new FilesystemPackageCacheManager.Builder().build();

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -85,7 +85,7 @@ public class Validator {
     // The two lines below turn off URL resolution checking in the validator. 
     // This eliminates the need to silence these errors elsewhere in Inferno
     // And also keeps contained resources from failing validation based solely on URL errors
-    ValidationControl vc = new BaseValidator(hl7Validator.getContext(), null, false)
+    ValidationControl vc = new BaseValidator(hl7Validator.getContext(), null, false, null)
                              .new ValidationControl(false, IssueSeverity.INFORMATION);
     hl7Validator.getValidationControl().put("Type_Specific_Checks_DT_URL_Resolve", vc);
 


### PR DESCRIPTION
# Summary
Bumps the core validator library to 6.5.0, with one trivial and one nontrivial change to keep up with the core engine. 

Trivial change: add a null to support a changing method signature.

Nontrivial change: Adds an explicit "policy advisor" to the engine that ensures it doesn't try to validate missing references beyond what is expected. The logic is derived from how it's done upstream in the ValidationService:
https://github.com/hapifhir/org.hl7.fhir.core/blob/e021fb31fd2303f5ad702c02b81a9c1c391697a8/org.hl7.fhir.validation/src/main/java/org/hl7/fhir/validation/cli/services/ValidationService.java#L610

Here we are essentially working with `disableDefaultResourceFetcher:true` so the logic is cloned from lines 616-618 and line 627, and slightly cleaned up. I don't know why there are 2 levels of PolicyAdvisor but that's how it works.

# Testing Guidance
The main reason we are bumping this is to fix a regression where references to resources not included in the validation request would always return a "not found" type error.

Sample resource:
```
{ "resourceType": "Observation", "subject": { "reference": "Patient/A" } }
```

Run this on https://inferno.healthit.gov/validator/:
> Observation.subject: Unable to resolve resource with reference 'Patient/A' on line 1.

Run this locally (eg, run with `./gradlew run` and POST that in the body to  `http://localhost:4567/validate` ) and that error should not occur. Other errors such as missing required fields should still be present.
