### PR TITLE
FI-3867: Bump core validator to 6.5.17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [16.x, 11.x]
+        java: [17.x, 11.x]
 
     name: Java ${{ matrix.java }} Build
     steps:
@@ -36,7 +36,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-${{ matrix.java }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.5.0")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.5.17")
 
     // validator dependency needed for terminology (why can't it get this automatically?)
     implementation("com.squareup.okhttp3", "okhttp", "4.12.0")

--- a/src/main/java/org/mitre/inferno/Validator.java
+++ b/src/main/java/org/mitre/inferno/Validator.java
@@ -36,6 +36,7 @@ import org.hl7.fhir.validation.BaseValidator;
 import org.hl7.fhir.validation.BaseValidator.ValidationControl;
 import org.hl7.fhir.validation.ValidationEngine;
 import org.hl7.fhir.validation.ValidationEngine.ValidationEngineBuilder;
+import org.hl7.fhir.validation.ValidatorSettings;
 import org.hl7.fhir.validation.cli.services.DisabledValidationPolicyAdvisor;
 import org.hl7.fhir.validation.instance.advisor.BasePolicyAdvisorForFullValidation;
 import org.mitre.inferno.rest.IgResponse;
@@ -88,7 +89,7 @@ public class Validator {
     // The two lines below turn off URL resolution checking in the validator. 
     // This eliminates the need to silence these errors elsewhere in Inferno
     // And also keeps contained resources from failing validation based solely on URL errors
-    ValidationControl vc = new BaseValidator(hl7Validator.getContext(), null, false, null)
+    ValidationControl vc = new BaseValidator(hl7Validator.getContext(), new ValidatorSettings(), null, null)
                              .new ValidationControl(false, IssueSeverity.INFORMATION);
     hl7Validator.getValidationControl().put("Type_Specific_Checks_DT_URL_Resolve", vc);
 

--- a/src/main/java/org/mitre/inferno/rest/IgResponse.java
+++ b/src/main/java/org/mitre/inferno/rest/IgResponse.java
@@ -6,10 +6,10 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.hl7.fhir.utilities.TextFile;
 import org.hl7.fhir.utilities.json.JsonUtilities;
 import org.hl7.fhir.utilities.npm.NpmPackage;
 
@@ -40,7 +40,7 @@ public class IgResponse {
    */
   public static IgResponse fromPackage(NpmPackage npm) throws IOException {
     InputStream in = npm.load(".index.json");
-    JsonObject index = (JsonObject) JsonParser.parseString(TextFile.streamToString(in));
+    JsonObject index = (JsonObject) JsonParser.parseReader(new InputStreamReader(in));
 
     JsonArray files = index.getAsJsonArray("files");
     List<String> profileUrls = new ArrayList<>();


### PR DESCRIPTION
# Summary
Bumps the core validator dependency to 6.5.17 purely to stay in sync with the latest release of the hl7 validator wrapper. 
There are a couple internal API changes so the other code changes here relate to fixing compilation errors as a result of the upgrade.

Also, apparently we were using very old workflow action versions which have been removed, so I bumped some versions to get CI working again.

# Testing Guidance
We're not expecting any differences in terms of validation results here. Start the server with `./gradlew run` and send some sample validations to `http://localhost:4567/validate` -- POST to that url and the body of the request is just the resource