### PR TITLE
Bump core validator version to 6.5.18

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.5.17")
+    implementation("ca.uhn.hapi.fhir", "org.hl7.fhir.validation", "6.5.18")
 
     // validator dependency needed for terminology (why can't it get this automatically?)
     implementation("com.squareup.okhttp3", "okhttp", "4.12.0")


### PR DESCRIPTION
# Summary
HL7 core validator release 6.5.18 includes support for the latest release of FHIR R6 ballot. Without this, choosing FHIR R6 core in the validator UI dropdown will break things.

The HL7 validator-wrapper is still on 6.5.17 so we'll be out of sync for a little bit, but that's preferable to this breaking. 

# Testing Guidance
Start the server with ./gradlew run and send some sample validations to http://localhost:4567/validate -- POST to that url and the body of the request is just the resource

To simulate loading R6 in a way that would previously break the app, `PUT http://localhost:4567/igs/hl7.fhir.r6.core?version=6.0.0-ballot3` with no body. On main currently this results in a 500 internal server

Note if you already have inferno running on port 4567, to choose a different port here: `VALIDATOR_PORT=8080 ./gradlew run`